### PR TITLE
Tweaks for usage in another project

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,12 @@ gulp.task('build-webpack', callback => {
 });
 
 gulp.task('compile-js-babel', () => {
-    return gulp.src(['src/**/*', '!src/**/*.py', '!src/browser.js'])
+    return gulp.src([
+      'src/**/*',
+      '!src/**/*.py',
+      '!src/core/brython-runner.worker.js',
+      '!src/browser.js',
+    ])
         .pipe(babel())
         .pipe(gulp.dest('lib'));
 });

--- a/lib/brython-runner.js
+++ b/lib/brython-runner.js
@@ -5,9 +5,9 @@ var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefau
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = void 0;
+exports.default = void 0;
 
 var _brythonRunner = _interopRequireDefault(require("./core/brython-runner"));
 
-var _default = _brythonRunner["default"];
-exports["default"] = _default;
+var _default = _brythonRunner.default;
+exports.default = _default;

--- a/lib/core/brython-runner.js
+++ b/lib/core/brython-runner.js
@@ -5,7 +5,7 @@ var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefau
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = void 0;
+exports.default = void 0;
 
 var _defineProperty2 = _interopRequireDefault(require("@babel/runtime/helpers/defineProperty"));
 
@@ -31,7 +31,7 @@ var _fileio = _interopRequireDefault(require("!!raw-loader!../scripts/fileio.py"
 
 function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { (0, _defineProperty2["default"])(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { (0, _defineProperty2.default)(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
 
 var DEFAULT_PARAMS = {
   codeName: 'main.py',
@@ -57,8 +57,8 @@ var DEFAULT_PARAMS = {
   },
   stdin: {
     readline: function readline() {
-      return (0, _asyncToGenerator2["default"])( /*#__PURE__*/_regenerator["default"].mark(function _callee() {
-        return _regenerator["default"].wrap(function _callee$(_context) {
+      return (0, _asyncToGenerator2.default)( /*#__PURE__*/_regenerator.default.mark(function _callee() {
+        return _regenerator.default.wrap(function _callee$(_context) {
           while (1) {
             switch (_context.prev = _context.next) {
               case 0:
@@ -86,12 +86,12 @@ var DEFAULT_PARAMS = {
 
 var BrythonRunner = /*#__PURE__*/function () {
   function BrythonRunner(params) {
-    (0, _classCallCheck2["default"])(this, BrythonRunner);
+    (0, _classCallCheck2.default)(this, BrythonRunner);
     this.setParamValues(params);
     this.initWorker();
   }
 
-  (0, _createClass2["default"])(BrythonRunner, [{
+  (0, _createClass2.default)(BrythonRunner, [{
     key: "setParamValues",
     value: function setParamValues(params) {
       var values = _objectSpread(_objectSpread({}, DEFAULT_PARAMS), params);
@@ -115,9 +115,9 @@ var BrythonRunner = /*#__PURE__*/function () {
         staticUrl: this.staticUrl,
         hangerUrl: this.hangerUrl,
         paths: this.paths,
-        initModules: [_brython["default"], _brython_stdlib["default"]],
+        initModules: [_brython.default, _brython_stdlib.default],
         postInitModules: this.postInitModules,
-        initScripts: [_stdio["default"], _sleep["default"], _fileio["default"]],
+        initScripts: [_stdio.default, _sleep.default, _fileio.default],
         postInitScripts: this.postInitScripts
       });
 
@@ -132,13 +132,13 @@ var BrythonRunner = /*#__PURE__*/function () {
       var blob;
 
       try {
-        blob = new Blob([_brythonRunnerWorker["default"]], {
+        blob = new Blob([_brythonRunnerWorker.default], {
           type: 'application/javascript'
         });
       } catch (e) {
         window.BlobBuilder = window.BlobBuilder || window.WebKitBlobBuilder || window.MozBlobBuilder;
         blob = new BlobBuilder();
-        blob.append(_brythonRunnerWorker["default"]);
+        blob.append(_brythonRunnerWorker.default);
         blob = blob.getBlob();
       }
 
@@ -147,9 +147,9 @@ var BrythonRunner = /*#__PURE__*/function () {
   }, {
     key: "handleMessage",
     value: function () {
-      var _handleMessage = (0, _asyncToGenerator2["default"])( /*#__PURE__*/_regenerator["default"].mark(function _callee2(msg) {
+      var _handleMessage = (0, _asyncToGenerator2.default)( /*#__PURE__*/_regenerator.default.mark(function _callee2(msg) {
         var data;
-        return _regenerator["default"].wrap(function _callee2$(_context2) {
+        return _regenerator.default.wrap(function _callee2$(_context2) {
           while (1) {
             switch (_context2.prev = _context2.next) {
               case 0:
@@ -313,4 +313,4 @@ var BrythonRunner = /*#__PURE__*/function () {
   return BrythonRunner;
 }();
 
-exports["default"] = BrythonRunner;
+exports.default = BrythonRunner;

--- a/lib/core/brython-runner.worker.js
+++ b/lib/core/brython-runner.worker.js
@@ -1,518 +1,266 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "/lib/";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./node_modules/@babel/runtime/helpers/assertThisInitialized.js":
+/*!**********************************************************************!*\
+  !*** ./node_modules/@babel/runtime/helpers/assertThisInitialized.js ***!
+  \**********************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("function _assertThisInitialized(self) {\n  if (self === void 0) {\n    throw new ReferenceError(\"this hasn't been initialised - super() hasn't been called\");\n  }\n\n  return self;\n}\n\nmodule.exports = _assertThisInitialized;\nmodule.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/assertThisInitialized.js?");
+
+/***/ }),
+
+/***/ "./node_modules/@babel/runtime/helpers/classCallCheck.js":
+/*!***************************************************************!*\
+  !*** ./node_modules/@babel/runtime/helpers/classCallCheck.js ***!
+  \***************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("function _classCallCheck(instance, Constructor) {\n  if (!(instance instanceof Constructor)) {\n    throw new TypeError(\"Cannot call a class as a function\");\n  }\n}\n\nmodule.exports = _classCallCheck;\nmodule.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/classCallCheck.js?");
+
+/***/ }),
+
+/***/ "./node_modules/@babel/runtime/helpers/construct.js":
+/*!**********************************************************!*\
+  !*** ./node_modules/@babel/runtime/helpers/construct.js ***!
+  \**********************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+eval("var setPrototypeOf = __webpack_require__(/*! ./setPrototypeOf.js */ \"./node_modules/@babel/runtime/helpers/setPrototypeOf.js\");\n\nvar isNativeReflectConstruct = __webpack_require__(/*! ./isNativeReflectConstruct.js */ \"./node_modules/@babel/runtime/helpers/isNativeReflectConstruct.js\");\n\nfunction _construct(Parent, args, Class) {\n  if (isNativeReflectConstruct()) {\n    module.exports = _construct = Reflect.construct;\n    module.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n  } else {\n    module.exports = _construct = function _construct(Parent, args, Class) {\n      var a = [null];\n      a.push.apply(a, args);\n      var Constructor = Function.bind.apply(Parent, a);\n      var instance = new Constructor();\n      if (Class) setPrototypeOf(instance, Class.prototype);\n      return instance;\n    };\n\n    module.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n  }\n\n  return _construct.apply(null, arguments);\n}\n\nmodule.exports = _construct;\nmodule.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/construct.js?");
+
+/***/ }),
+
+/***/ "./node_modules/@babel/runtime/helpers/createClass.js":
+/*!************************************************************!*\
+  !*** ./node_modules/@babel/runtime/helpers/createClass.js ***!
+  \************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("function _defineProperties(target, props) {\n  for (var i = 0; i < props.length; i++) {\n    var descriptor = props[i];\n    descriptor.enumerable = descriptor.enumerable || false;\n    descriptor.configurable = true;\n    if (\"value\" in descriptor) descriptor.writable = true;\n    Object.defineProperty(target, descriptor.key, descriptor);\n  }\n}\n\nfunction _createClass(Constructor, protoProps, staticProps) {\n  if (protoProps) _defineProperties(Constructor.prototype, protoProps);\n  if (staticProps) _defineProperties(Constructor, staticProps);\n  return Constructor;\n}\n\nmodule.exports = _createClass;\nmodule.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/createClass.js?");
+
+/***/ }),
+
+/***/ "./node_modules/@babel/runtime/helpers/get.js":
+/*!****************************************************!*\
+  !*** ./node_modules/@babel/runtime/helpers/get.js ***!
+  \****************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+eval("var superPropBase = __webpack_require__(/*! ./superPropBase.js */ \"./node_modules/@babel/runtime/helpers/superPropBase.js\");\n\nfunction _get(target, property, receiver) {\n  if (typeof Reflect !== \"undefined\" && Reflect.get) {\n    module.exports = _get = Reflect.get;\n    module.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n  } else {\n    module.exports = _get = function _get(target, property, receiver) {\n      var base = superPropBase(target, property);\n      if (!base) return;\n      var desc = Object.getOwnPropertyDescriptor(base, property);\n\n      if (desc.get) {\n        return desc.get.call(receiver);\n      }\n\n      return desc.value;\n    };\n\n    module.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n  }\n\n  return _get(target, property, receiver || target);\n}\n\nmodule.exports = _get;\nmodule.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/get.js?");
+
+/***/ }),
+
+/***/ "./node_modules/@babel/runtime/helpers/getPrototypeOf.js":
+/*!***************************************************************!*\
+  !*** ./node_modules/@babel/runtime/helpers/getPrototypeOf.js ***!
+  \***************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("function _getPrototypeOf(o) {\n  module.exports = _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) {\n    return o.__proto__ || Object.getPrototypeOf(o);\n  };\n  module.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n  return _getPrototypeOf(o);\n}\n\nmodule.exports = _getPrototypeOf;\nmodule.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/getPrototypeOf.js?");
+
+/***/ }),
+
+/***/ "./node_modules/@babel/runtime/helpers/inherits.js":
+/*!*********************************************************!*\
+  !*** ./node_modules/@babel/runtime/helpers/inherits.js ***!
+  \*********************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+eval("var setPrototypeOf = __webpack_require__(/*! ./setPrototypeOf.js */ \"./node_modules/@babel/runtime/helpers/setPrototypeOf.js\");\n\nfunction _inherits(subClass, superClass) {\n  if (typeof superClass !== \"function\" && superClass !== null) {\n    throw new TypeError(\"Super expression must either be null or a function\");\n  }\n\n  subClass.prototype = Object.create(superClass && superClass.prototype, {\n    constructor: {\n      value: subClass,\n      writable: true,\n      configurable: true\n    }\n  });\n  if (superClass) setPrototypeOf(subClass, superClass);\n}\n\nmodule.exports = _inherits;\nmodule.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/inherits.js?");
+
+/***/ }),
+
+/***/ "./node_modules/@babel/runtime/helpers/isNativeFunction.js":
+/*!*****************************************************************!*\
+  !*** ./node_modules/@babel/runtime/helpers/isNativeFunction.js ***!
+  \*****************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("function _isNativeFunction(fn) {\n  return Function.toString.call(fn).indexOf(\"[native code]\") !== -1;\n}\n\nmodule.exports = _isNativeFunction;\nmodule.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/isNativeFunction.js?");
+
+/***/ }),
+
+/***/ "./node_modules/@babel/runtime/helpers/isNativeReflectConstruct.js":
+/*!*************************************************************************!*\
+  !*** ./node_modules/@babel/runtime/helpers/isNativeReflectConstruct.js ***!
+  \*************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("function _isNativeReflectConstruct() {\n  if (typeof Reflect === \"undefined\" || !Reflect.construct) return false;\n  if (Reflect.construct.sham) return false;\n  if (typeof Proxy === \"function\") return true;\n\n  try {\n    Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function () {}));\n    return true;\n  } catch (e) {\n    return false;\n  }\n}\n\nmodule.exports = _isNativeReflectConstruct;\nmodule.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/isNativeReflectConstruct.js?");
+
+/***/ }),
+
+/***/ "./node_modules/@babel/runtime/helpers/possibleConstructorReturn.js":
+/*!**************************************************************************!*\
+  !*** ./node_modules/@babel/runtime/helpers/possibleConstructorReturn.js ***!
+  \**************************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+eval("var _typeof = __webpack_require__(/*! @babel/runtime/helpers/typeof */ \"./node_modules/@babel/runtime/helpers/typeof.js\")[\"default\"];\n\nvar assertThisInitialized = __webpack_require__(/*! ./assertThisInitialized.js */ \"./node_modules/@babel/runtime/helpers/assertThisInitialized.js\");\n\nfunction _possibleConstructorReturn(self, call) {\n  if (call && (_typeof(call) === \"object\" || typeof call === \"function\")) {\n    return call;\n  }\n\n  return assertThisInitialized(self);\n}\n\nmodule.exports = _possibleConstructorReturn;\nmodule.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/possibleConstructorReturn.js?");
+
+/***/ }),
+
+/***/ "./node_modules/@babel/runtime/helpers/setPrototypeOf.js":
+/*!***************************************************************!*\
+  !*** ./node_modules/@babel/runtime/helpers/setPrototypeOf.js ***!
+  \***************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("function _setPrototypeOf(o, p) {\n  module.exports = _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) {\n    o.__proto__ = p;\n    return o;\n  };\n\n  module.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n  return _setPrototypeOf(o, p);\n}\n\nmodule.exports = _setPrototypeOf;\nmodule.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/setPrototypeOf.js?");
+
+/***/ }),
+
+/***/ "./node_modules/@babel/runtime/helpers/superPropBase.js":
+/*!**************************************************************!*\
+  !*** ./node_modules/@babel/runtime/helpers/superPropBase.js ***!
+  \**************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+eval("var getPrototypeOf = __webpack_require__(/*! ./getPrototypeOf.js */ \"./node_modules/@babel/runtime/helpers/getPrototypeOf.js\");\n\nfunction _superPropBase(object, property) {\n  while (!Object.prototype.hasOwnProperty.call(object, property)) {\n    object = getPrototypeOf(object);\n    if (object === null) break;\n  }\n\n  return object;\n}\n\nmodule.exports = _superPropBase;\nmodule.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/superPropBase.js?");
+
+/***/ }),
+
+/***/ "./node_modules/@babel/runtime/helpers/typeof.js":
+/*!*******************************************************!*\
+  !*** ./node_modules/@babel/runtime/helpers/typeof.js ***!
+  \*******************************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("function _typeof(obj) {\n  \"@babel/helpers - typeof\";\n\n  if (typeof Symbol === \"function\" && typeof Symbol.iterator === \"symbol\") {\n    module.exports = _typeof = function _typeof(obj) {\n      return typeof obj;\n    };\n\n    module.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n  } else {\n    module.exports = _typeof = function _typeof(obj) {\n      return obj && typeof Symbol === \"function\" && obj.constructor === Symbol && obj !== Symbol.prototype ? \"symbol\" : typeof obj;\n    };\n\n    module.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n  }\n\n  return _typeof(obj);\n}\n\nmodule.exports = _typeof;\nmodule.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/typeof.js?");
+
+/***/ }),
+
+/***/ "./node_modules/@babel/runtime/helpers/wrapNativeSuper.js":
+/*!****************************************************************!*\
+  !*** ./node_modules/@babel/runtime/helpers/wrapNativeSuper.js ***!
+  \****************************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+eval("var getPrototypeOf = __webpack_require__(/*! ./getPrototypeOf.js */ \"./node_modules/@babel/runtime/helpers/getPrototypeOf.js\");\n\nvar setPrototypeOf = __webpack_require__(/*! ./setPrototypeOf.js */ \"./node_modules/@babel/runtime/helpers/setPrototypeOf.js\");\n\nvar isNativeFunction = __webpack_require__(/*! ./isNativeFunction.js */ \"./node_modules/@babel/runtime/helpers/isNativeFunction.js\");\n\nvar construct = __webpack_require__(/*! ./construct.js */ \"./node_modules/@babel/runtime/helpers/construct.js\");\n\nfunction _wrapNativeSuper(Class) {\n  var _cache = typeof Map === \"function\" ? new Map() : undefined;\n\n  module.exports = _wrapNativeSuper = function _wrapNativeSuper(Class) {\n    if (Class === null || !isNativeFunction(Class)) return Class;\n\n    if (typeof Class !== \"function\") {\n      throw new TypeError(\"Super expression must either be null or a function\");\n    }\n\n    if (typeof _cache !== \"undefined\") {\n      if (_cache.has(Class)) return _cache.get(Class);\n\n      _cache.set(Class, Wrapper);\n    }\n\n    function Wrapper() {\n      return construct(Class, arguments, getPrototypeOf(this).constructor);\n    }\n\n    Wrapper.prototype = Object.create(Class.prototype, {\n      constructor: {\n        value: Wrapper,\n        enumerable: false,\n        writable: true,\n        configurable: true\n      }\n    });\n    return setPrototypeOf(Wrapper, Class);\n  };\n\n  module.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n  return _wrapNativeSuper(Class);\n}\n\nmodule.exports = _wrapNativeSuper;\nmodule.exports[\"default\"] = module.exports, module.exports.__esModule = true;\n\n//# sourceURL=webpack:///./node_modules/@babel/runtime/helpers/wrapNativeSuper.js?");
+
+/***/ }),
+
+/***/ "./src/core/brython-runner.worker.js":
+/*!*******************************************!*\
+  !*** ./src/core/brython-runner.worker.js ***!
+  \*******************************************/
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
 "use strict";
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony import */ var _babel_runtime_helpers_classCallCheck__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/helpers/classCallCheck */ \"./node_modules/@babel/runtime/helpers/classCallCheck.js\");\n/* harmony import */ var _babel_runtime_helpers_classCallCheck__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_classCallCheck__WEBPACK_IMPORTED_MODULE_0__);\n/* harmony import */ var _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @babel/runtime/helpers/createClass */ \"./node_modules/@babel/runtime/helpers/createClass.js\");\n/* harmony import */ var _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1__);\n/* harmony import */ var _babel_runtime_helpers_get__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @babel/runtime/helpers/get */ \"./node_modules/@babel/runtime/helpers/get.js\");\n/* harmony import */ var _babel_runtime_helpers_get__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_get__WEBPACK_IMPORTED_MODULE_2__);\n/* harmony import */ var _babel_runtime_helpers_inherits__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! @babel/runtime/helpers/inherits */ \"./node_modules/@babel/runtime/helpers/inherits.js\");\n/* harmony import */ var _babel_runtime_helpers_inherits__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_inherits__WEBPACK_IMPORTED_MODULE_3__);\n/* harmony import */ var _babel_runtime_helpers_possibleConstructorReturn__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! @babel/runtime/helpers/possibleConstructorReturn */ \"./node_modules/@babel/runtime/helpers/possibleConstructorReturn.js\");\n/* harmony import */ var _babel_runtime_helpers_possibleConstructorReturn__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_possibleConstructorReturn__WEBPACK_IMPORTED_MODULE_4__);\n/* harmony import */ var _babel_runtime_helpers_getPrototypeOf__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! @babel/runtime/helpers/getPrototypeOf */ \"./node_modules/@babel/runtime/helpers/getPrototypeOf.js\");\n/* harmony import */ var _babel_runtime_helpers_getPrototypeOf__WEBPACK_IMPORTED_MODULE_5___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_getPrototypeOf__WEBPACK_IMPORTED_MODULE_5__);\n/* harmony import */ var _babel_runtime_helpers_wrapNativeSuper__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! @babel/runtime/helpers/wrapNativeSuper */ \"./node_modules/@babel/runtime/helpers/wrapNativeSuper.js\");\n/* harmony import */ var _babel_runtime_helpers_wrapNativeSuper__WEBPACK_IMPORTED_MODULE_6___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_wrapNativeSuper__WEBPACK_IMPORTED_MODULE_6__);\n\n\n\n\n\n\n\n\nfunction _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _babel_runtime_helpers_getPrototypeOf__WEBPACK_IMPORTED_MODULE_5___default()(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _babel_runtime_helpers_getPrototypeOf__WEBPACK_IMPORTED_MODULE_5___default()(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _babel_runtime_helpers_possibleConstructorReturn__WEBPACK_IMPORTED_MODULE_4___default()(this, result); }; }\n\nfunction _isNativeReflectConstruct() { if (typeof Reflect === \"undefined\" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === \"function\") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }\n\nfunction _createForOfIteratorHelper(o, allowArrayLike) { var it; if (typeof Symbol === \"undefined\" || o[Symbol.iterator] == null) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === \"number\") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError(\"Invalid attempt to iterate non-iterable instance.\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.\"); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = o[Symbol.iterator](); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }\n\nfunction _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === \"string\") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === \"Object\" && o.constructor) n = o.constructor.name; if (n === \"Map\" || n === \"Set\") return Array.from(o); if (n === \"Arguments\" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }\n\nfunction _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }\n\nfunction _brInitRunner(data) {\n  _brSetValues(data);\n\n  _brOverwrite();\n\n  _brInitMsgSenders();\n\n  _brInitMsgListeners();\n\n  _brRunModuleScripts(data);\n\n  _brInitBrython(data);\n\n  _brRunInitPythonScripts(data);\n\n  _brOverrideOpen();\n\n  _brRunPostInitPythonScripts(data);\n\n  _brInitRunnerCallback();\n}\n\nfunction _brSetValues(data) {\n  self._brLocalPathPrefix = '/__pythonpad_local__';\n  self._brRunType = 'code';\n  self._brId = data.codeName;\n  self._brCodeCwd = data.codeCwd;\n  self._brCode = '';\n  self._brHangerUrl = data.hangerUrl;\n  self._brImportLocalFile = _brImportLocalFile;\n  self._brFilesUpdated = _brFilesUpdated;\n  self._brHangSleep = _brHangSleep;\n  self._brPrevErrOut = null;\n}\n\nfunction _brOverwrite() {\n  self.window = self;\n  self.prompt = _brGetInput;\n  self.document = _brCreateMockDocument();\n}\n\nfunction _brCreateMockDocument() {\n  return {\n    getElementsByTagName: _brGetElementsByTagName\n  };\n}\n\nfunction _brRunModuleScripts(data) {\n  var _iterator = _createForOfIteratorHelper(data.initModules),\n      _step;\n\n  try {\n    for (_iterator.s(); !(_step = _iterator.n()).done;) {\n      var rawModule = _step.value;\n      eval.call(null, rawModule);\n    }\n  } catch (err) {\n    _iterator.e(err);\n  } finally {\n    _iterator.f();\n  }\n\n  var _iterator2 = _createForOfIteratorHelper(data.postInitModules),\n      _step2;\n\n  try {\n    for (_iterator2.s(); !(_step2 = _iterator2.n()).done;) {\n      var _rawModule = _step2.value;\n      eval.call(null, _rawModule);\n    }\n  } catch (err) {\n    _iterator2.e(err);\n  } finally {\n    _iterator2.f();\n  }\n}\n\nfunction _brInitBrython(data) {\n  self.RealXMLHttpRequest = self.XMLHttpRequest;\n  self.XMLHttpRequest = _brXHR;\n\n  self.__BRYTHON__.brython({\n    pythonpath: [self._brLocalPathPrefix].concat(data.paths),\n    debug: data.debug || 0\n  });\n}\n\nfunction _brRunInitPythonScripts(data) {\n  _brRun(data.initScripts.join('\\n'));\n}\n\nfunction _brOverrideOpen() {\n  self.__BRYTHON__.builtins.open = self._brOpenFile;\n}\n\nfunction _brRunPostInitPythonScripts(data) {\n  for (var i = 0; i < data.postInitScripts.length; i++) {\n    _brRun(data.postInitScripts[i]);\n  }\n}\n\nfunction _brInitRunnerCallback() {\n  self.postMessage({\n    type: 'brython.init',\n    value: ''\n  });\n}\n\nfunction _brImportLocalFile(filename) {\n  if (self._brFilesObj[filename] && self._brFilesObj[filename].type === 'text') {\n    return self._brFilesObj[filename].body;\n  } else {\n    return null;\n  }\n}\n\nfunction _brSetFiles(files) {\n  self._brFilesObj = files;\n\n  self._brSetFilesFromObj();\n}\n\nfunction _brFilesUpdated(filename, type, body) {\n  if (!type && !body) {\n    delete self._brFilesObj[filename];\n    self.postMessage({\n      type: 'file.delete',\n      value: filename\n    });\n  } else {\n    self._brFilesObj[filename] = {\n      type: type,\n      body: body\n    };\n    self.postMessage({\n      type: 'file.update',\n      value: {\n        filename: filename,\n        data: {\n          type: type,\n          body: body\n        }\n      }\n    });\n  }\n}\n\nfunction _brGetInput(message) {\n  if (self._brHangerUrl === null) {\n    self._brRaiseInputError();\n\n    return '';\n  }\n\n  if (message) {\n    self._brStdoutWrite(message + '');\n\n    self._brStdoutFlush();\n  }\n\n  var req = new RealXMLHttpRequest();\n  console.log('URL', self._brHangerUrl + '/open/');\n  req.open('POST', self._brHangerUrl + '/open/', false);\n  req.send('');\n\n  if (req.status !== 200) {\n    console.error('Failed to tunnel through the server to get input.');\n    return '';\n  }\n\n  var key = req.responseText;\n  self.postMessage({\n    type: 'stdin.readline',\n    value: key\n  });\n  req = new RealXMLHttpRequest();\n  req.open('POST', self._brHangerUrl + '/' + key + '/read/', false);\n  req.send('');\n\n  if (req.status !== 200) {\n    console.error('Failed to tunnel through the server to get input.');\n    return '';\n  }\n\n  return req.responseText;\n}\n\nfunction _brHangSleep(duration) {\n  var req = new RealXMLHttpRequest();\n  req.open('GET', self._brHangerUrl + '/sleep/?duration=' + duration, false);\n  req.send(null);\n}\n\nfunction _brGetElementsByTagName(tagName) {\n  if (tagName === 'script') {\n    if (self._brRunType === 'code') {\n      return [{\n        type: 'text/python',\n        id: self._brId,\n        innerHTML: self._brCode\n      }];\n    } else if (self._brRunType === 'url') {\n      return [{\n        type: 'text/python',\n        id: getFilename(self._brUrl),\n        src: self._brUrl\n      }];\n    }\n  }\n\n  return [];\n}\n\nfunction _brInitMsgSenders() {\n  self._brStdoutWrite = function (data) {\n    self._brPrevErrOut = null;\n    self.postMessage({\n      type: 'stdout.write',\n      value: data\n    });\n  };\n\n  self._brStdoutFlush = function () {\n    self.postMessage({\n      type: 'stdout.flush'\n    });\n  };\n\n  self._brStderrWrite = function (data) {\n    if ((data + '').startsWith('Traceback (most recent call last):') && data === self._brPrevErrOut) {\n      return; // Skip duplicated error message.\n    }\n\n    self._brPrevErrOut = data;\n    self.postMessage({\n      type: 'stderr.write',\n      value: data\n    });\n  };\n\n  self._brStderrFlush = function () {\n    self.postMessage({\n      type: 'stderr.flush'\n    });\n  };\n\n  self._brSendMsg = function (type, value) {\n    self.postMessage({\n      type: type,\n      value: value\n    });\n  };\n}\n\nfunction _brInitMsgListeners() {\n  self._brMsgListeners = {};\n\n  self._brAddMsgListener = function (type, callback) {\n    if (!(type in self._brMsgListeners)) {\n      self._brMsgListeners[type] = [callback];\n    } else {\n      self._brMsgListeners[type].push(callback);\n    }\n  };\n\n  self._brRemoveMsgListener = function (type, callback) {\n    if (type in self._brMsgListeners) {\n      var newMsgListeners = [];\n\n      for (var i = 0; i < self._brMsgListeners[type].length; i++) {\n        if (self._brMsgListeners[type][i] !== callback) {\n          newMsgListeners.push(self._brMsgListeners[type][i]);\n        }\n      }\n\n      self._brMsgListeners[type] = newMsgListeners;\n    }\n  };\n\n  self.receiveMsg = function (type) {\n    return new Promise(function (resolve, reject) {\n      var callback = function callback(msg) {\n        resolve(msg.value);\n\n        self._brRemoveMsgListener(type, callback);\n      };\n\n      self._brAddMsgListener(type, callback);\n    });\n  };\n}\n\nfunction getFilename(url) {\n  var splitUrl = url.split('/');\n  return splitUrl[splitUrl.length - 1];\n}\n\nfunction getParentUrl(url) {\n  var splitUrl = url.split('/');\n\n  if (splitUrl.length === 1) {\n    return './';\n  } else {\n    return splitUrl.slice(0, splitUrl.length - 1).join('/');\n  }\n}\n\nfunction _brRun(src) {\n  self._brPrevErrOut = null;\n  self._brRunType = 'code';\n  self._brCode = src;\n  var pathBackup = self.__BRYTHON__.script_path;\n  self.__BRYTHON__.script_path = self._brCodeCwd;\n\n  try {\n    self.__BRYTHON__.parser._run_scripts({});\n  } catch (err) {} finally {\n    self.__BRYTHON__.script_path = pathBackup;\n  }\n}\n\nfunction _brRunUrl(url) {\n  self._brPrevErrOut = null;\n  self._brRunType = 'url';\n  self._brUrl = url;\n  var pathBackup = self.__BRYTHON__.script_path;\n  self.__BRYTHON__.script_path = getParentUrl(url);\n\n  try {\n    self.__BRYTHON__.parser._run_scripts({});\n  } catch (err) {} finally {\n    self.__BRYTHON__.script_path = pathBackup;\n  }\n}\n\nfunction _brRunCallback(exit) {\n  self.postMessage({\n    type: 'done',\n    exit: exit\n  });\n}\n\nvar _brXHR = /*#__PURE__*/function (_XMLHttpRequest) {\n  _babel_runtime_helpers_inherits__WEBPACK_IMPORTED_MODULE_3___default()(_brXHR, _XMLHttpRequest);\n\n  var _super = _createSuper(_brXHR);\n\n  function _brXHR() {\n    var _this;\n\n    _babel_runtime_helpers_classCallCheck__WEBPACK_IMPORTED_MODULE_0___default()(this, _brXHR);\n\n    _this = _super.call(this);\n    _this.localPrefix = self._brLocalPathPrefix + '/';\n    _this.localRequestOpened = false;\n    _this.localRequestSent = false;\n    _this.localResponseText = null;\n    return _this;\n  }\n\n  _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default()(_brXHR, [{\n    key: \"open\",\n    value: function open() {\n      var _get2;\n\n      for (var _len = arguments.length, params = new Array(_len), _key = 0; _key < _len; _key++) {\n        params[_key] = arguments[_key];\n      }\n\n      if (params.length > 1) {\n        var url = params[1];\n\n        if (url.startsWith(this.localPrefix)) {\n          var localPath = url.slice(this.localPrefix.length, url.indexOf('?'));\n          this.localResponseText = _brImportLocalFile(localPath);\n          this.localRequestOpened = true; // TODO: Call onreadystatechange.\n\n          return;\n        }\n      }\n\n      return (_get2 = _babel_runtime_helpers_get__WEBPACK_IMPORTED_MODULE_2___default()(_babel_runtime_helpers_getPrototypeOf__WEBPACK_IMPORTED_MODULE_5___default()(_brXHR.prototype), \"open\", this)).call.apply(_get2, [this].concat(params));\n    }\n  }, {\n    key: \"send\",\n    value: function send() {\n      if (this.localRequestOpened) {\n        this.localRequestSent = true;\n      } else {\n        var _get3;\n\n        for (var _len2 = arguments.length, params = new Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {\n          params[_key2] = arguments[_key2];\n        }\n\n        return (_get3 = _babel_runtime_helpers_get__WEBPACK_IMPORTED_MODULE_2___default()(_babel_runtime_helpers_getPrototypeOf__WEBPACK_IMPORTED_MODULE_5___default()(_brXHR.prototype), \"send\", this)).call.apply(_get3, [this].concat(params));\n      }\n    }\n  }, {\n    key: \"status\",\n    get: function get() {\n      if (this.localRequestOpened) {\n        if (this.localResponseText === null) {\n          return 404;\n        } else {\n          return 200;\n        }\n      } else {\n        return _babel_runtime_helpers_get__WEBPACK_IMPORTED_MODULE_2___default()(_babel_runtime_helpers_getPrototypeOf__WEBPACK_IMPORTED_MODULE_5___default()(_brXHR.prototype), \"status\", this);\n      }\n    }\n  }, {\n    key: \"readyState\",\n    get: function get() {\n      if (this.localRequestOpened) {\n        if (this.localRequestSent) {\n          return 4;\n        } else {\n          return 1;\n        }\n      } else {\n        return _babel_runtime_helpers_get__WEBPACK_IMPORTED_MODULE_2___default()(_babel_runtime_helpers_getPrototypeOf__WEBPACK_IMPORTED_MODULE_5___default()(_brXHR.prototype), \"readyState\", this);\n      }\n    }\n  }, {\n    key: \"responseText\",\n    get: function get() {\n      if (this.localRequestOpened) {\n        return this.localResponseText;\n      } else {\n        return _babel_runtime_helpers_get__WEBPACK_IMPORTED_MODULE_2___default()(_babel_runtime_helpers_getPrototypeOf__WEBPACK_IMPORTED_MODULE_5___default()(_brXHR.prototype), \"responseText\", this);\n      }\n    }\n  }]);\n\n  return _brXHR;\n}( /*#__PURE__*/_babel_runtime_helpers_wrapNativeSuper__WEBPACK_IMPORTED_MODULE_6___default()(XMLHttpRequest));\n\nself.onmessage = function (message) {\n  var data = message.data;\n\n  switch (data.type) {\n    case 'init':\n      _brInitRunner(data);\n\n      break;\n\n    case 'run.code':\n      try {\n        _brRun(data.code);\n\n        _brRunCallback(0);\n      } catch (err) {\n        _brRunCallback(1);\n      }\n\n      break;\n\n    case 'run.code-with-files':\n      try {\n        _brSetFiles(data.files);\n\n        _brRun(data.code);\n\n        _brRunCallback(0);\n      } catch (err) {\n        _brRunCallback(1);\n      }\n\n      break;\n\n    case 'run.url':\n      try {\n        _brRunUrl(data.url);\n\n        _brRunCallback(0);\n      } catch (err) {\n        _brRunCallback(1);\n      }\n\n      break;\n\n    default:\n      break;\n  }\n\n  if (data.type in self._brMsgListeners) {\n    for (var i = 0; i < self._brMsgListeners[data.type].length; i++) {\n      self._brMsgListeners[data.type][i](data);\n    }\n  }\n};\n\n//# sourceURL=webpack:///./src/core/brython-runner.worker.js?");
 
-var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+/***/ }),
 
-var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
+/***/ 1:
+/*!*************************************************!*\
+  !*** multi ./src/core/brython-runner.worker.js ***!
+  \*************************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
 
-var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
+eval("module.exports = __webpack_require__(/*! ./src/core/brython-runner.worker.js */\"./src/core/brython-runner.worker.js\");\n\n\n//# sourceURL=webpack:///multi_./src/core/brython-runner.worker.js?");
 
-var _get4 = _interopRequireDefault(require("@babel/runtime/helpers/get"));
+/***/ })
 
-var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
-
-var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
-
-var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
-
-var _wrapNativeSuper2 = _interopRequireDefault(require("@babel/runtime/helpers/wrapNativeSuper"));
-
-function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = (0, _getPrototypeOf2["default"])(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = (0, _getPrototypeOf2["default"])(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return (0, _possibleConstructorReturn2["default"])(this, result); }; }
-
-function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
-function _createForOfIteratorHelper(o, allowArrayLike) { var it; if (typeof Symbol === "undefined" || o[Symbol.iterator] == null) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = o[Symbol.iterator](); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it["return"] != null) it["return"](); } finally { if (didErr) throw err; } } }; }
-
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
-
-function _brInitRunner(data) {
-  _brSetValues(data);
-
-  _brOverwrite();
-
-  _brInitMsgSenders();
-
-  _brInitMsgListeners();
-
-  _brRunModuleScripts(data);
-
-  _brInitBrython(data);
-
-  _brRunInitPythonScripts(data);
-
-  _brOverrideOpen();
-
-  _brRunPostInitPythonScripts(data);
-
-  _brInitRunnerCallback();
-}
-
-function _brSetValues(data) {
-  self._brLocalPathPrefix = '/__pythonpad_local__';
-  self._brRunType = 'code';
-  self._brId = data.codeName;
-  self._brCodeCwd = data.codeCwd;
-  self._brCode = '';
-  self._brHangerUrl = data.hangerUrl;
-  self._brImportLocalFile = _brImportLocalFile;
-  self._brFilesUpdated = _brFilesUpdated;
-  self._brHangSleep = _brHangSleep;
-  self._brPrevErrOut = null;
-}
-
-function _brOverwrite() {
-  self.window = self;
-  self.prompt = _brGetInput;
-  self.document = _brCreateMockDocument();
-}
-
-function _brCreateMockDocument() {
-  return {
-    getElementsByTagName: _brGetElementsByTagName
-  };
-}
-
-function _brRunModuleScripts(data) {
-  var _iterator = _createForOfIteratorHelper(data.initModules),
-      _step;
-
-  try {
-    for (_iterator.s(); !(_step = _iterator.n()).done;) {
-      var rawModule = _step.value;
-      eval.call(null, rawModule);
-    }
-  } catch (err) {
-    _iterator.e(err);
-  } finally {
-    _iterator.f();
-  }
-
-  var _iterator2 = _createForOfIteratorHelper(data.postInitModules),
-      _step2;
-
-  try {
-    for (_iterator2.s(); !(_step2 = _iterator2.n()).done;) {
-      var _rawModule = _step2.value;
-      eval.call(null, _rawModule);
-    }
-  } catch (err) {
-    _iterator2.e(err);
-  } finally {
-    _iterator2.f();
-  }
-}
-
-function _brInitBrython(data) {
-  self.RealXMLHttpRequest = self.XMLHttpRequest;
-  self.XMLHttpRequest = _brXHR;
-
-  self.__BRYTHON__.brython({
-    pythonpath: [self._brLocalPathPrefix].concat(data.paths),
-    debug: data.debug || 0
-  });
-}
-
-function _brRunInitPythonScripts(data) {
-  _brRun(data.initScripts.join('\n'));
-}
-
-function _brOverrideOpen() {
-  self.__BRYTHON__.builtins.open = self._brOpenFile;
-}
-
-function _brRunPostInitPythonScripts(data) {
-  for (var i = 0; i < data.postInitScripts.length; i++) {
-    _brRun(data.postInitScripts[i]);
-  }
-}
-
-function _brInitRunnerCallback() {
-  self.postMessage({
-    type: 'brython.init',
-    value: ''
-  });
-}
-
-function _brImportLocalFile(filename) {
-  if (self._brFilesObj[filename] && self._brFilesObj[filename].type === 'text') {
-    return self._brFilesObj[filename].body;
-  } else {
-    return null;
-  }
-}
-
-function _brSetFiles(files) {
-  self._brFilesObj = files;
-
-  self._brSetFilesFromObj();
-}
-
-function _brFilesUpdated(filename, type, body) {
-  if (!type && !body) {
-    delete self._brFilesObj[filename];
-    self.postMessage({
-      type: 'file.delete',
-      value: filename
-    });
-  } else {
-    self._brFilesObj[filename] = {
-      type: type,
-      body: body
-    };
-    self.postMessage({
-      type: 'file.update',
-      value: {
-        filename: filename,
-        data: {
-          type: type,
-          body: body
-        }
-      }
-    });
-  }
-}
-
-function _brGetInput(message) {
-  if (self._brHangerUrl === null) {
-    self._brRaiseInputError();
-
-    return '';
-  }
-
-  if (message) {
-    self._brStdoutWrite(message + '');
-
-    self._brStdoutFlush();
-  }
-
-  var req = new RealXMLHttpRequest();
-  console.log('URL', self._brHangerUrl + '/open/');
-  req.open('POST', self._brHangerUrl + '/open/', false);
-  req.send('');
-
-  if (req.status !== 200) {
-    console.error('Failed to tunnel through the server to get input.');
-    return '';
-  }
-
-  var key = req.responseText;
-  self.postMessage({
-    type: 'stdin.readline',
-    value: key
-  });
-  req = new RealXMLHttpRequest();
-  req.open('POST', self._brHangerUrl + '/' + key + '/read/', false);
-  req.send('');
-
-  if (req.status !== 200) {
-    console.error('Failed to tunnel through the server to get input.');
-    return '';
-  }
-
-  return req.responseText;
-}
-
-function _brHangSleep(duration) {
-  var req = new RealXMLHttpRequest();
-  req.open('GET', self._brHangerUrl + '/sleep/?duration=' + duration, false);
-  req.send(null);
-}
-
-function _brGetElementsByTagName(tagName) {
-  if (tagName === 'script') {
-    if (self._brRunType === 'code') {
-      return [{
-        type: 'text/python',
-        id: self._brId,
-        innerHTML: self._brCode
-      }];
-    } else if (self._brRunType === 'url') {
-      return [{
-        type: 'text/python',
-        id: getFilename(self._brUrl),
-        src: self._brUrl
-      }];
-    }
-  }
-
-  return [];
-}
-
-function _brInitMsgSenders() {
-  self._brStdoutWrite = function (data) {
-    self._brPrevErrOut = null;
-    self.postMessage({
-      type: 'stdout.write',
-      value: data
-    });
-  };
-
-  self._brStdoutFlush = function () {
-    self.postMessage({
-      type: 'stdout.flush'
-    });
-  };
-
-  self._brStderrWrite = function (data) {
-    if ((data + '').startsWith('Traceback (most recent call last):') && data === self._brPrevErrOut) {
-      return; // Skip duplicated error message.
-    }
-
-    self._brPrevErrOut = data;
-    self.postMessage({
-      type: 'stderr.write',
-      value: data
-    });
-  };
-
-  self._brStderrFlush = function () {
-    self.postMessage({
-      type: 'stderr.flush'
-    });
-  };
-
-  self._brSendMsg = function (type, value) {
-    self.postMessage({
-      type: type,
-      value: value
-    });
-  };
-}
-
-function _brInitMsgListeners() {
-  self._brMsgListeners = {};
-
-  self._brAddMsgListener = function (type, callback) {
-    if (!(type in self._brMsgListeners)) {
-      self._brMsgListeners[type] = [callback];
-    } else {
-      self._brMsgListeners[type].push(callback);
-    }
-  };
-
-  self._brRemoveMsgListener = function (type, callback) {
-    if (type in self._brMsgListeners) {
-      var newMsgListeners = [];
-
-      for (var i = 0; i < self._brMsgListeners[type].length; i++) {
-        if (self._brMsgListeners[type][i] !== callback) {
-          newMsgListeners.push(self._brMsgListeners[type][i]);
-        }
-      }
-
-      self._brMsgListeners[type] = newMsgListeners;
-    }
-  };
-
-  self.receiveMsg = function (type) {
-    return new Promise(function (resolve, reject) {
-      var callback = function callback(msg) {
-        resolve(msg.value);
-
-        self._brRemoveMsgListener(type, callback);
-      };
-
-      self._brAddMsgListener(type, callback);
-    });
-  };
-}
-
-function getFilename(url) {
-  var splitUrl = url.split('/');
-  return splitUrl[splitUrl.length - 1];
-}
-
-function getParentUrl(url) {
-  var splitUrl = url.split('/');
-
-  if (splitUrl.length === 1) {
-    return './';
-  } else {
-    return splitUrl.slice(0, splitUrl.length - 1).join('/');
-  }
-}
-
-function _brRun(src) {
-  self._brPrevErrOut = null;
-  self._brRunType = 'code';
-  self._brCode = src;
-  var pathBackup = self.__BRYTHON__.script_path;
-  self.__BRYTHON__.script_path = self._brCodeCwd;
-
-  try {
-    self.__BRYTHON__.parser._run_scripts({});
-  } catch (err) {} finally {
-    self.__BRYTHON__.script_path = pathBackup;
-  }
-}
-
-function _brRunUrl(url) {
-  self._brPrevErrOut = null;
-  self._brRunType = 'url';
-  self._brUrl = url;
-  var pathBackup = self.__BRYTHON__.script_path;
-  self.__BRYTHON__.script_path = getParentUrl(url);
-
-  try {
-    self.__BRYTHON__.parser._run_scripts({});
-  } catch (err) {} finally {
-    self.__BRYTHON__.script_path = pathBackup;
-  }
-}
-
-function _brRunCallback(exit) {
-  self.postMessage({
-    type: 'done',
-    exit: exit
-  });
-}
-
-var _brXHR = /*#__PURE__*/function (_XMLHttpRequest) {
-  (0, _inherits2["default"])(_brXHR, _XMLHttpRequest);
-
-  var _super = _createSuper(_brXHR);
-
-  function _brXHR() {
-    var _this;
-
-    (0, _classCallCheck2["default"])(this, _brXHR);
-    _this = _super.call(this);
-    _this.localPrefix = self._brLocalPathPrefix + '/';
-    _this.localRequestOpened = false;
-    _this.localRequestSent = false;
-    _this.localResponseText = null;
-    return _this;
-  }
-
-  (0, _createClass2["default"])(_brXHR, [{
-    key: "open",
-    value: function open() {
-      var _get2;
-
-      for (var _len = arguments.length, params = new Array(_len), _key = 0; _key < _len; _key++) {
-        params[_key] = arguments[_key];
-      }
-
-      if (params.length > 1) {
-        var url = params[1];
-
-        if (url.startsWith(this.localPrefix)) {
-          var localPath = url.slice(this.localPrefix.length, url.indexOf('?'));
-          this.localResponseText = _brImportLocalFile(localPath);
-          this.localRequestOpened = true; // TODO: Call onreadystatechange.
-
-          return;
-        }
-      }
-
-      return (_get2 = (0, _get4["default"])((0, _getPrototypeOf2["default"])(_brXHR.prototype), "open", this)).call.apply(_get2, [this].concat(params));
-    }
-  }, {
-    key: "send",
-    value: function send() {
-      if (this.localRequestOpened) {
-        this.localRequestSent = true;
-      } else {
-        var _get3;
-
-        for (var _len2 = arguments.length, params = new Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
-          params[_key2] = arguments[_key2];
-        }
-
-        return (_get3 = (0, _get4["default"])((0, _getPrototypeOf2["default"])(_brXHR.prototype), "send", this)).call.apply(_get3, [this].concat(params));
-      }
-    }
-  }, {
-    key: "status",
-    get: function get() {
-      if (this.localRequestOpened) {
-        if (this.localResponseText === null) {
-          return 404;
-        } else {
-          return 200;
-        }
-      } else {
-        return (0, _get4["default"])((0, _getPrototypeOf2["default"])(_brXHR.prototype), "status", this);
-      }
-    }
-  }, {
-    key: "readyState",
-    get: function get() {
-      if (this.localRequestOpened) {
-        if (this.localRequestSent) {
-          return 4;
-        } else {
-          return 1;
-        }
-      } else {
-        return (0, _get4["default"])((0, _getPrototypeOf2["default"])(_brXHR.prototype), "readyState", this);
-      }
-    }
-  }, {
-    key: "responseText",
-    get: function get() {
-      if (this.localRequestOpened) {
-        return this.localResponseText;
-      } else {
-        return (0, _get4["default"])((0, _getPrototypeOf2["default"])(_brXHR.prototype), "responseText", this);
-      }
-    }
-  }]);
-  return _brXHR;
-}( /*#__PURE__*/(0, _wrapNativeSuper2["default"])(XMLHttpRequest));
-
-self.onmessage = function (message) {
-  var data = message.data;
-
-  switch (data.type) {
-    case 'init':
-      _brInitRunner(data);
-
-      break;
-
-    case 'run.code':
-      try {
-        _brRun(data.code);
-
-        _brRunCallback(0);
-      } catch (err) {
-        _brRunCallback(1);
-      }
-
-      break;
-
-    case 'run.code-with-files':
-      try {
-        _brSetFiles(data.files);
-
-        _brRun(data.code);
-
-        _brRunCallback(0);
-      } catch (err) {
-        _brRunCallback(1);
-      }
-
-      break;
-
-    case 'run.url':
-      try {
-        _brRunUrl(data.url);
-
-        _brRunCallback(0);
-      } catch (err) {
-        _brRunCallback(1);
-      }
-
-      break;
-
-    default:
-      break;
-  }
-
-  if (data.type in self._brMsgListeners) {
-    for (var i = 0; i < self._brMsgListeners[data.type].length; i++) {
-      self._brMsgListeners[data.type][i](data);
-    }
-  }
-};
+/******/ });

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "yargs": "^15.3.1"
   },
   "dependencies": {
+    "@babel/runtime": "^7.12.1",
     "brython": "3.8.10",
     "raw-loader": "^4.0.1"
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ module.exports = mode => ({
     mode: 'development',
     entry: {
         'brython-runner.bundle': mode === 'development' ? ['babel-polyfill', './src/browser.js'] : ['./src/browser.js'],
+        'core/brython-runner.worker': mode === 'development' ? ['babel-polyfill', './src/core/brython-runner.worker.js'] : ['./src/core/brython-runner.worker.js'],
     },
     output: {
         path: path.join(__dirname, 'lib'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -806,6 +806,13 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
+"@babel/runtime@^7.12.1":
+  version "7.13.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
+  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.8.4":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.2.tgz#d103f21f2602497d38348a32e008637d506db839"


### PR DESCRIPTION
Hi there!

I was trying to use this library in another project and ran into some problems:

1. The module `@babel/runtime` was missing from `brython-runner` dependency list. So, when I used `import BrythonRunner from 'brython-runner/lib/brython-runner.js'`, webpack complained that could not find the modules required by the code generated by the `@babel/plugin-transform-runtime` plugin.
2. The module `lib/core/brython-runner.js` loads `lib/core/brython-runner.worker.js` as a raw string, so calls like `require("@babel/runtime/...")` generated by `@babel/plugin-transform-runtime` are not resolved by webpack. That results in the code failing to execute in the Web worker.

In this pull request I address problem (1) by adding `@babel/runtime` as a dependency, as recommended by the [documentation](https://babeljs.io/docs/en/babel-plugin-transform-runtime#installation). This is done in the first commit.

As for problem (2), instead of generating `lib/core/brython-runner.worker.js` in the `compile-js-babel` Gulp task, I change the build configuration so that `lib/core/brython-runner.worker.js` is generated as a bundle by webpack. This is done in the second commit.

Finally, the third commit regenerates files in `lib/`, which was done via `yarn run build`.

I hope the changes proposed here do not break other workflows already in use! :-) If they do, what would be the way of using this library in another project using webpack?

Best regards,
Gustavo Sousa